### PR TITLE
path argument is now passed into "get_and_check_project_file"

### DIFF
--- a/as4_to_as6_analyzer.py
+++ b/as4_to_as6_analyzer.py
@@ -437,7 +437,7 @@ def main():
     print(f"Script build number: {build_number}")
 
     args = parse_args()
-    apj_file = utils.get_and_check_project_file("C")
+    apj_file = utils.get_and_check_project_file(args.project_path)
 
     utils.set_verbose(args.verbose)
 


### PR DESCRIPTION
Using any project path in the tool would generate this error:

<img width="594" height="277" alt="image" src="https://github.com/user-attachments/assets/03fe358d-64a1-44c0-9832-6fd0c10b4f76" />

This change reverts to using args.project_path to pass the project path instead of using the hard-coded path of 'C'