### PR TITLE
#48: Add information about File device whitelist for mappView access

### DIFF
--- a/as4_to_as6_analyzer.py
+++ b/as4_to_as6_analyzer.py
@@ -771,18 +771,23 @@ def main():
                     f"\n\nFound usage of mappView (Version: {mappView_settings_results['version']}). Several security settings will be enforced after the migration."
                     "\n"
                     "\n- To allow access without a certificate"
-                    "\n  Change the following settings in the OPC Client/Server configuration (Physical View/Connectivity/OpcUaCs/UaCsConfig.uacfg):"
+                    "\n  Change the following settings in the OPC Client/Server configuration (Configuration View/Connectivity/OpcUaCs/UaCsConfig.uacfg):"
                     "\n  ClientServerConfiguration->Security->MessageSecurity->SecurityPolicies->None: Enabled"
                     "\n"
                     "\n- User login will be enabled by default. To allow anonymous access"
                     "\n  Change the following settings in mappView configuration (Configuration View/mappView/Config.mappviewcfg):"
                     "\n  MappViewConfiguration->Server Configuration->Startup User: anonymous token"
                     "\n"
-                    "\n  Change the following settings in the OPC Client/Server configuration (Configuration View/Connectivity/OpcUaCs/UaCsConfig.uacfg):"
+                    "\n- Change the following settings in the OPC Client/Server configuration (Configuration View/Connectivity/OpcUaCs/UaCsConfig.uacfg):"
                     "\n  ClientServerConfiguration->Security->Authentication->Authentication Methods->Anymous: Enabled"
                     "\n"
-                    "\n  Change the following settings in the User role system (Configuration View/AccessAndSecurity/UserRoleSystem/User.user)"
+                    "\n- Change the following settings in the User role system (Configuration View/AccessAndSecurity/UserRoleSystem/User.user):"
                     '\n  Assign the role "BR_Engineer" to the user "Anonymous". Create that user if it doesn\'t already exist, assign no password.'
+                    "\n"
+                    "\n- To allow access to a File device from a running mappView application, it is now required to explicitly whitelist it for reading:"
+                    "\n  - Open the mappView server configuration file Configuration View/mappView/Config.mappviewcfg)"
+                    '\n  - Check "Change Advanced Parameter Visibility" button in the editor toolbar'
+                    '\n  - Enter your accessed File device "Name" under "MappViewConfiguration->Server configuration->File device whitelist"'
                 )
 
                 # Verbose: Print detailed information about mappVision locations if verbose mode is enabled


### PR DESCRIPTION
This resolves issues #48 

Adds information that the user has to whitelist their file devices explicitly when accessing them from mappView "pre compilation" now.

Also took the liberty to fix the alignment and the wording of the mappView config info block

Output of the testing:
<img width="958" height="306" alt="image" src="https://github.com/user-attachments/assets/6dc920b5-604d-46fa-8475-9d43a2f42099" />
