### PR TITLE
Implementation of more precise detection for mappView widget library

### DIFF
--- a/as4_to_as6_analyzer.py
+++ b/as4_to_as6_analyzer.py
@@ -140,7 +140,7 @@ def main():
         check_safety(apj_path, log, args.verbose)  # Safety system issues
         check_vision_settings(apj_path, log, args.verbose)  # mappVision issues
         check_mappView(apj_path, log, args.verbose)  # mappView issues
-        check_wdk_usage(logical_path, log, args.verbose)  # Detect WDK
+        check_widget_lib_usage(logical_path, log, args.verbose)  # Detect widget libraries (WDK usage or User Widget Libraries from AS4)
         check_mapp_version(apj_path, log, args.verbose)  # mappService/mapp version issues
 
         # Finish up

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -6,7 +6,7 @@ from .hardware_check import check_hardware
 from .library_check import check_libraries
 from .mapp_services import check_mapp_version
 from .mapp_view import check_mappView
-from .mapp_view_wdk import check_wdk_usage
+from .mapp_view_wdk import check_widget_lib_usage
 from .mapp_vision import check_vision_settings
 from .opc_ua import check_uad_files
 from .safety_check import check_safety

--- a/checks/mapp_view_wdk.py
+++ b/checks/mapp_view_wdk.py
@@ -15,6 +15,14 @@ Action:
 import os
 from pathlib import Path
 from typing import Iterator, Optional
+from enum import Enum
+import xml.etree.ElementTree as ET
+
+class WidgetLibraryType(Enum):
+    WDK = "WDK"
+    WDTC = "WDTC"
+    USER_WIDGET_LIB_4 = "User Widget Library 4"
+    USER_WIDGET_LIB_6 = "User Widget Library 6"
 
 
 def _find_widgets_roots(logical_path: Path) -> Iterator[Path]:
@@ -45,53 +53,108 @@ def _find_first_wdk_folder(widgets_root: Path) -> Optional[Path]:
             return Path(folder)
     return None
 
-
-def check_wdk_usage(logical_path: Path, log, verbose: bool = False) -> None:
+def _detect_widget_library_type(widget_lib_path: Path) -> Optional[WidgetLibraryType]:
     """
-    Detect usage of the legacy mappView *WDK* (Widget Development Kit) and warn that it
+    Detect the type of widget library by the path to the base folder of the widget library.
+    Returns one of the WidgetLibraryType enum values.
+
+    For WDK & WDTC:
+    - In base folder: "mappView/Widgets/{library_name}", a file "WidgetLibrary.mapping" should exist.
+    - To diff WDK & WDTC, the file "WidgetLibrary.mapping" in WDTC each "Mapping" node as a attribute "oType", that didn't exist in WDK.
+
+    For Widget Library 4 & 6:
+    - In base folder: "mappView/Widgets/{library_name}", a file "Description.widgetlibrary" should exist.
+    - To diff 4 & 6, we compare the "version" attribute in the file (it's mappView version)
+    """
+
+    if not widget_lib_path or not widget_lib_path.exists() or not widget_lib_path.is_dir():
+        return None
+
+    mapping_file = widget_lib_path / "WidgetLibrary.mapping"
+    if mapping_file.exists():
+        # Parse xml file WidgetLibrary.mapping and search for the first "Mappings/Mapping" in the Mapping node test if a <oType> attribute exists
+        tree = ET.parse(mapping_file)
+        root = tree.getroot()
+        mapping_node = root.find("Mappings/Mapping")
+        if mapping_node is not None and mapping_node.get("oType") is not None:
+            return WidgetLibraryType.WDTC
+        elif mapping_node is not None:
+            return WidgetLibraryType.WDK
+
+
+    description_file = widget_lib_path / "Description.widgetlibrary"
+    if description_file.exists():
+        with description_file.open() as f:
+            content = f.read()
+            if 'version="5.' in content:
+                return WidgetLibraryType.USER_WIDGET_LIB_4
+            elif 'version="6.' in content:
+                return WidgetLibraryType.USER_WIDGET_LIB_6
+
+    return None
+
+
+def check_widget_lib_usage(logical_path: Path, log, verbose: bool = False) -> None:
+    """
+    Detect usage of the legacy mappView *WDK* (Widget Development Kit) or User widget libraries and warn that it
     must be migrated to *WDTC* (Widget Development Tool Chain) in AS6.
 
     Detection:
     - Look for a 'Widgets' folder under any 'mappView' directory inside the project's 'Logical' tree.
-    - If any folder under that 'Widgets' root (including itself) contains BOTH a '.js' file and a '.html' file
-      in the same folder, the project is considered to be using WDK.
-    - Stop scanning after the first hit (we only need to know that WDK is used).
+    - For each directory under 'Widgets', detect the type of the widget libraries (WDK, WDTC, User Widget Library 4, User Widget Library 6).
 
     Logging:
-    - Severity: MANDATORY
+    - Severity: MANDATORY (WDK) / WARNING (User Widget Libraries 4)
     - Scope: AS6
     - Include a community link for WDTC migration info.
-    - Log one example path to a detected folder (there may be more).
+    - Log path to the library folder.
     """
     if verbose:
-        log("Checking for legacy mappView WDK usage...")
+        log("Checking for legacy mappView WDK and User widget library usage...")
 
     widgets_roots = list(_find_widgets_roots(logical_path))
     if not widgets_roots:
         if verbose:
             log("No 'mappView/Widgets' folders found under Logical.", severity="INFO")
         return
-
-    example_hit: Optional[Path] = None
+    nb_lib_to_change_found: int = 0
     for root in widgets_roots:
-        example_hit = _find_first_wdk_folder(root)
-        if example_hit:
-            break
+        libraries_folder: str = [f.path for f in os.scandir(root) if f.is_dir()]
+        for library in libraries_folder:
+            lib_path = Path(library)
+            rel = lib_path.relative_to(logical_path)
+            lib_name = lib_path.name
+            lib_type = _detect_widget_library_type(lib_path)
+            if lib_type != WidgetLibraryType.USER_WIDGET_LIB_6 and lib_type != WidgetLibraryType.WDTC:
+                nb_lib_to_change_found += 1
 
-    if example_hit:
-        try:
-            rel = example_hit.relative_to(logical_path)
-        except Exception:
-            rel = example_hit
-        log(
-            "WDK (Widget Development Kit) detected - it is deprecated and no longer supported in AS6."
-            "\n - In AS6, you must migrate to WDTC (Widget Development Tool Chain)."
-            "\n - For more information, visit the B&R Community: https://community.br-automation.com/c/wdtc/10"
-            f"\n - Example WDK-like widget folder (one or more may exist): {rel}",
-            when="AS6",
-            severity="MANDATORY",
-        )
+            if lib_type == WidgetLibraryType.WDK:
+                if verbose:
+                    log(f"Found WDK library: {lib_name} ({rel})")
+                
+                log(
+                    f"Widget library {lib_name} ({rel}) appears to be a WDK (Widget Development Kit) library, which is deprecated and no longer supported in AS6."
+                    "For more information, visit the B&R Community: https://community.br-automation.com/c/wdtc/10",
+                    when="AS6",
+                    severity="MANDATORY"
+                )
+            elif lib_type == WidgetLibraryType.WDTC:
+                if verbose:
+                    log(f"Found WDTC library: {lib_name} ({rel})")
+            elif lib_type == WidgetLibraryType.USER_WIDGET_LIB_4:
+                if verbose:
+                    log(f"Found User Widget Library 4: {lib_name} ({rel})")
+                
+                log(
+                    f"Widget library {lib_name} ({rel}) appears to be a User Widget Library from AS 4, which may not be compatible with AS6."
+                    "Please migrate to User Widget Library 6.",
+                    when="AS6",
+                    severity="WARNING"
+                )
+            elif lib_type == WidgetLibraryType.USER_WIDGET_LIB_6:
+                if verbose:
+                    log(f"Found User Widget Library 6: {lib_name} ({rel})")
 
-    else:
+    if nb_lib_to_change_found == 0:
         if verbose:
-            log("No WDK usage detected in mappView/Widgets.", severity="INFO")
+            log("No WDK usage or User Widget Library detected in mappView/Widgets.", severity="INFO")


### PR DESCRIPTION
Hi,

I've modify the way we detect WDK and add the detection of widget library type (WDK, WDTC, User widget library from AS4, , User widget library from AS6).

Old detection was done based on detection of a file .js and .html in same folder. Now we detect for each library the type, if it's a WDK or User widget library from AS4, we log details.
The details of the detection is in docstring of the function "_detect_widget_library_type"

For User widget library I don't really know if there is some migration to do but it just log a warning based on the version to inform the user.

That's a first commit, maybe we could put it under the mappview.py check now.

Happy to heard your comments :)

Regards,
Florent