### PR TITLE
Remove telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
   <a href="https://github.com/br-automation-community/as6-migration-tools/releases" target="_blank" rel="noopener noreferrer">
     <img src="https://img.shields.io/github/downloads/br-automation-community/as6-migration-tools/total.svg" alt="Total downloads"/>
   </a>
-  <img src="https://img.shields.io/badge/dynamic/json?label=Runs&query=%24.value&url=https%3A%2F%2Fabacus.jasoncameron.dev%2Fget%2Fas6-migration-tools-6f2a48c7%2Frun-clicks&cacheSeconds=300" alt="Script runs"/>
   <a href="https://github.com/hilch/BandR-badges/blob/main/Made-For-BrAutomation.svg" target="_blank" rel="noopener noreferrer">
     <img src="https://github.com/hilch/BandR-badges/blob/main/Made-For-BrAutomation.svg" alt="Made for B&R"/>
   </a>

--- a/as4_to_as6_analyzer.py
+++ b/as4_to_as6_analyzer.py
@@ -106,9 +106,6 @@ def main():
     def log(message, when="", severity=""):
         utils.log(message, log_file=file_handle, when=when, severity=severity)
 
-    # Anonymous, non-blocking usage ping (never blocks, never surfaces errors)
-    utils.bump_counter_async("run-clicks")
-
     try:
         log(
             "Scanning started... Please wait while the script analyzes your project files."


### PR DESCRIPTION
* While it's nice to know, how many people use it and how often, I think it's not really outweighing the following con:

* It possibly violates the GDPR, because the user's IP is not just sent but also (even if just for that purpose) stored -> see the "Rate Limiting?" FAQ here: https://v2.jasoncameron.dev/abacus/
  * Users are not informed (actually in the readme it says "No telemetry", which is, of course, not true)

Even if not in violation, I know of specially "security aware" people who even change the captive portal adress in android away from google which is also not collecting any data but "might know their IP".